### PR TITLE
fix: Mismatched signature between checker plugin API and implementation

### DIFF
--- a/mypy/plugin.py
+++ b/mypy/plugin.py
@@ -240,7 +240,7 @@ class CheckerPluginInterface:
 
     @abstractmethod
     def fail(
-        self, msg: str | ErrorMessage, ctx: Context, *, code: ErrorCode | None = None
+        self, msg: str | ErrorMessage, ctx: Context, /, *, code: ErrorCode | None = None
     ) -> None:
         """Emit an error message at given location."""
         raise NotImplementedError


### PR DESCRIPTION
This PR changes the `fail` method's signature to be positional-only for the first two parameters, due to a mismatch between the [`CheckerPluginInterface` signature](https://github.com/python/mypy/blob/8dd268ffd84ccf549b3aa9105dd35766a899b2bd/mypy/plugin.py#L242-L244) and the implementation class ([`TypeChecker`](https://github.com/python/mypy/blob/8dd268ffd84ccf549b3aa9105dd35766a899b2bd/mypy/checker.py#L7116-L7118)).

```python
class CheckerPluginInterface:
    ...
    @abstractmethod
    def fail(
        self, msg: str | ErrorMessage, ctx: Context, *, code: ErrorCode | None = None
    ) -> None: ...
```

```python
class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
    ...
    def fail(
        self, msg: str | ErrorMessage, context: Context, *, code: ErrorCode | None = None
    ) -> None:
```

An alternative fix would be to change `TypeChecker.fail`'s parameter name to `ctx`, but that has a greater disruption potential.